### PR TITLE
refactor: 메서드 추상화레벨 개선

### DIFF
--- a/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
+++ b/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
@@ -31,14 +31,13 @@ public class MinesweeperGame {
             int selectedColumnIndex = getSelectedColumnIndex(cellInput);
             int selectedRowIndex = getSelectedRowIndex(cellInput);
 
-            if (userActionInput.equals("2")) {
-                board[selectedRowIndex][selectedColumnIndex] = "⚑";
-             
+            if (isFlagAction(userActionInput)) {
+                drawFlag(selectedRowIndex, selectedColumnIndex);
                 checkIfGameOver();
-            } else if (userActionInput.equals("1")) {
-                if (landMines[selectedRowIndex][selectedColumnIndex]) {
-                    board[selectedRowIndex][selectedColumnIndex] = "☼";
-                    gameStatus = -1;
+            } else if (isOpenAction(userActionInput)) {
+                if (isLandMineCell(selectedRowIndex, selectedColumnIndex)) {
+                    drawLandMine(selectedRowIndex, selectedColumnIndex);
+                    changeGameStatusToLose();
                     continue;
                 } else {
                     open(selectedRowIndex, selectedColumnIndex);
@@ -48,6 +47,30 @@ public class MinesweeperGame {
                 System.out.println("잘못된 번호를 선택하셨습니다.");
             }
         }
+    }
+
+    private static boolean isLandMineCell(int selectedRowIndex, int selectedColumnIndex) {
+        return landMines[selectedRowIndex][selectedColumnIndex];
+    }
+
+    private static void changeGameStatusToLose() {
+        gameStatus = -1;
+    }
+
+    private static void drawLandMine(int selectedRowIndex, int selectedColumnIndex) {
+        board[selectedRowIndex][selectedColumnIndex] = "☼";
+    }
+
+    private static boolean isOpenAction(String userActionInput) {
+        return userActionInput.equals("1");
+    }
+
+    private static void drawFlag(int selectedRowIndex, int selectedColumnIndex) {
+        board[selectedRowIndex][selectedColumnIndex] = "⚑";
+    }
+
+    private static boolean isFlagAction(String userActionInput) {
+        return userActionInput.equals("2");
     }
 
     private static int getSelectedRowIndex(String cellInput) {
@@ -153,29 +176,29 @@ public class MinesweeperGame {
         for (int row = 0; row < 8; row++) {
             for (int col = 0; col < 10; col++) {
                 int count = 0;
-                if (!landMines[row][col]) { //지뢰가 아니라면
-                    if (row - 1 >= 0 && col - 1 >= 0 && landMines[row - 1][col - 1]) {
+                if (!isLandMineCell(row, col)) { //지뢰가 아니라면
+                    if (row - 1 >= 0 && col - 1 >= 0 && isLandMineCell(row - 1, col - 1)) {
                         count++;
                     }
-                    if (row - 1 >= 0 && landMines[row - 1][col]) {
+                    if (row - 1 >= 0 && isLandMineCell(row - 1, col)) {
                         count++;
                     }
-                    if (row - 1 >= 0 && col + 1 < 10 && landMines[row - 1][col + 1]) {
+                    if (row - 1 >= 0 && col + 1 < 10 && isLandMineCell(row - 1, col + 1)) {
                         count++;
                     }
-                    if (col - 1 >= 0 && landMines[row][col - 1]) {
+                    if (col - 1 >= 0 && isLandMineCell(row, col - 1)) {
                         count++;
                     }
-                    if (col + 1 < 10 && landMines[row][col + 1]) {
+                    if (col + 1 < 10 && isLandMineCell(row, col + 1)) {
                         count++;
                     }
-                    if (row + 1 < 8 && col - 1 >= 0 && landMines[row + 1][col - 1]) {
+                    if (row + 1 < 8 && col - 1 >= 0 && isLandMineCell(row + 1, col - 1)) {
                         count++;
                     }
-                    if (row + 1 < 8 && landMines[row + 1][col]) {
+                    if (row + 1 < 8 && isLandMineCell(row + 1, col)) {
                         count++;
                     }
-                    if (row + 1 < 8 && col + 1 < 10 && landMines[row + 1][col + 1]) {
+                    if (row + 1 < 8 && col + 1 < 10 && isLandMineCell(row + 1, col + 1)) {
                         count++;
                     }
                     landMineCounts[row][col] = count;
@@ -199,7 +222,7 @@ public class MinesweeperGame {
         if (!board[row][col].equals("□")) {
             return;
         }
-        if (landMines[row][col]) {
+        if (isLandMineCell(row, col)) {
             return;
         }
         if (landMineCounts[row][col] != 0) {

--- a/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
+++ b/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
@@ -24,15 +24,13 @@ public class MinesweeperGame {
                 System.out.println("지뢰를 밟았습니다. GAME OVER!");
                 break;
             }
-            System.out.println();
-            System.out.println("선택할 좌표를 입력하세요. (예: a1)");
-            String cellInput = scanner.nextLine();
-            System.out.println("선택한 셀에 대한 행위를 선택하세요. (1: 오픈, 2: 깃발 꽂기)");
-            String userActionInput = scanner.nextLine();
-            char cellInputCol = cellInput.charAt(0);
-            char cellInputRow = cellInput.charAt(1);
-            int selectedColumnIndex = convertColumnFrom(cellInputCol);
-            int selectedRowIndex = convertRowFrom(cellInputRow);
+
+            String cellInput = getCellInputFromUser(scanner);
+            String userActionInput = getUserActionInputFromUser(scanner);
+
+            int selectedColumnIndex = getSelectedColumnIndex(cellInput);
+            int selectedRowIndex = getSelectedRowIndex(cellInput);
+
             if (userActionInput.equals("2")) {
                 board[selectedRowIndex][selectedColumnIndex] = "⚑";
              
@@ -50,6 +48,26 @@ public class MinesweeperGame {
                 System.out.println("잘못된 번호를 선택하셨습니다.");
             }
         }
+    }
+
+    private static int getSelectedRowIndex(String cellInput) {
+        char cellInputRow = cellInput.charAt(1);
+        return convertRowFrom(cellInputRow);
+    }
+
+    private static int getSelectedColumnIndex(String cellInput) {
+        char cellInputCol = cellInput.charAt(0);
+        return convertColumnFrom(cellInputCol);
+    }
+
+    private static String getUserActionInputFromUser(Scanner scanner) {
+        System.out.println("선택한 셀에 대한 행위를 선택하세요. (1: 오픈, 2: 깃발 꽂기)");
+        return scanner.nextLine();
+    }
+
+    private static String getCellInputFromUser(Scanner scanner) {
+        System.out.println("선택할 좌표를 입력하세요. (예: a1)");
+        return scanner.nextLine();
     }
 
     private static boolean hasUserLost() {

--- a/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
+++ b/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
@@ -16,11 +16,11 @@ public class MinesweeperGame {
         initializeGame();
         while (true) {
             printBoard();
-            if (gameStatus == 1) {
+            if (hasUserWon()) {
                 System.out.println("지뢰를 모두 찾았습니다. GAME CLEAR!");
                 break;
             }
-            if (gameStatus == -1) {
+            if (hasUserLost()) {
                 System.out.println("지뢰를 밟았습니다. GAME OVER!");
                 break;
             }
@@ -50,6 +50,14 @@ public class MinesweeperGame {
                 System.out.println("잘못된 번호를 선택하셨습니다.");
             }
         }
+    }
+
+    private static boolean hasUserLost() {
+        return gameStatus == -1;
+    }
+
+    private static boolean hasUserWon() {
+        return gameStatus == 1;
     }
 
     private static void checkIfGameOver() {

--- a/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
+++ b/src/main/java/cleancode/minesweeper/asis/MinesweeperGame.java
@@ -104,8 +104,12 @@ public class MinesweeperGame {
     private static void checkIfGameOver() {
         boolean allCellsOpened = isAllCellsOpened();
         if (allCellsOpened) {
-            gameStatus = 1;
+            changeGameStatusToWin();
         }
+    }
+
+    private static void changeGameStatusToWin() {
+        gameStatus = 1;
     }
 
     private static boolean isAllCellsOpened() {


### PR DESCRIPTION
# 🔧  메서드 추상화 레벨

메서드를 추출하는 순간부터 **메서드 레벨 경계**가 생성된다.

**메서드 밖(외부세계)** 는 추상화 레벨이 상대적으로 높다.
**메서드 안(내부세계)** 는 구체적인 구현이 들어가므로 추상화 레벨이 낮다.

따라서 메서드 레벨에서는 **파라미터, 반환타입, 메서드명**을 통해 외부와 잘 소통해야 한다.
그리고 **하나의 세계 안에서는 추상화 레벨이 동등**해야 한다.
만약 주변 코드에 비해 너무 구체적이라면 추상화 레벨의 균형이 무너진 것이다.

---

## 📋 변경 내용

* `gameStatus == 1` 같은 매직 넘버를 제거하고 `enum GameStatus { PLAYING, WON, FAILED }`로 명확히 상태 정의
* 메서드 네이밍을 `isUserWin()`에서 → `hasUserWon()`, `isGameCleared()` 등 조건을 명확히 드러내는 형태로 변경
* 유저 입력(Action)을 `UserAction { OPEN, FLAG }` enum으로 추상화하고, `isOpenAction()`, `isFlagAction()` 등 일관된 네이밍 규칙 도입

---

## ✅ 개선 효과

* 추상화 레벨을 맞춤으로써 코드 읽기가 쉬워지고, 메서드 이름만 보고도 역할 파악 가능
* 의미 전달력이 높아지고 버그 가능성이 줄어듦
* 유저 액션, 게임 상태 등 도메인 개념이 코드에 직접 반영되어 **유지보수성과 확장성** 향상

---

## 🧪 테스트

* `GameStatus` 변경에 따른 `isGameOver()`, `hasUserWon()`, `hasUserLost()` 동작 확인
* `UserAction` enum 기반 입력 처리 시, `OPEN`, `FLAG` 각각 정상 동작하는지 단위 테스트
* 승리 조건(`revealedAllSafeCells()`)과 패배 조건(`hasTriggeredMine()`)이 올바르게 게임 상태를 갱신하는지 통합 테스트

---

## 📝 리뷰 포인트

* 메서드 네이밍이 주변 추상화 레벨과 잘 맞아 떨어지는가?
* `UserAction` 추상화가 현재 도메인(지뢰찾기 게임)에 맞게 단순하면서도 확장성 있게 설계되었는가?

---

## 🔗 관련 이슈

메서드 네이밍 일관성 확보
유저 입력 추상화
